### PR TITLE
feat: update generated file extension from .g.dart to .validasi.dart

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -31,6 +31,7 @@ include: package:lints/recommended.yaml
 analyzer:
   exclude:
     - "**/*.g.dart" # Ignore all files ending with .g.dart
+    - "**/*.validasi.dart" # Ignore all files ending with .validasi.dart
     - "build/**"    # Ignore the entire 'build' directory
     - ".dart_tool/build/**" # Ignore the build directory under .dart_tool
     - "**/*.mocks.dart" # Ignore all files ending with .mocks.dart

--- a/docs/companion/form-management/with-codegen.md
+++ b/docs/companion/form-management/with-codegen.md
@@ -10,7 +10,7 @@ The recommended path: annotate your model, run `build_runner`, use the generated
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass()
 class User {

--- a/docs/companion/generator/configuration.md
+++ b/docs/companion/generator/configuration.md
@@ -44,6 +44,14 @@ class InternalOnly {
 
 Per-class settings take precedence over `build.yaml` for the three flags that support them.
 
+## Name-collision suffixing
+
+A field literally named `name`, `extract`, `validate`, or `validateAsync` collides with an
+instance member the generated `XFields` hierarchy requires, so the generator suffixes the
+static accessor with an underscore (`UserFields.name_` instead of `UserFields.name`). The
+field's runtime `.name` getter still reports the real, unsuffixed name — only the static
+accessor identifier changes.
+
 ## Recommended configs
 
 ### Dart-only (no Flutter, no forms)

--- a/docs/companion/generator/overview.md
+++ b/docs/companion/generator/overview.md
@@ -21,7 +21,7 @@ Annotate a model:
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass()
 class User {
@@ -44,7 +44,7 @@ Run the generator:
 dart run build_runner build
 ```
 
-This produces `user.g.dart` containing a sealed field class hierarchy and validation
+This produces `user.validasi.dart` containing a sealed field class hierarchy and validation
 extension methods on `User`.
 
 ## Annotation rules vs `Rules.*`

--- a/docs/companion/generator/standalone.md
+++ b/docs/companion/generator/standalone.md
@@ -19,7 +19,7 @@ No `flutter` dependency — just Dart.
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass()
 class User {

--- a/docs/companion/generator/with-ui.md
+++ b/docs/companion/generator/with-ui.md
@@ -41,7 +41,7 @@ targets:
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass()
 class User {
@@ -66,7 +66,7 @@ dart run build_runner build --delete-conflicting-outputs
 
 ## What gets generated
 
-The generator produces `user.g.dart` with:
+The generator produces `user.validasi.dart` with:
 
 ```dart
 // Sealed field key hierarchy — one const per field

--- a/packages/validasi_gen/ARCH.md
+++ b/packages/validasi_gen/ARCH.md
@@ -49,7 +49,7 @@
                │
                ▼
 ┌───────────────────────────────┐
-│ Output: user.g.dart             │
+│ Output: user.validasi.dart             │
 │   sealed class UserFields<V> …  │
 │   class _UserSchema … { … }     │
 │   extension $UserValidasi on User {
@@ -90,7 +90,7 @@ The `build_runner` entry point. It:
 2. Instantiates `ValidasiGenerator` with those four as its `*Default` constructor parameters.
 3. Reads the source library and runs the generator.
 4. If the generator returns non-empty output, wraps it in the `part of '…';` header and runs it through `DartFormatter` (page width 80, latest language version) — falling back to the unformatted source if formatting throws.
-5. Writes to `*.g.dart` next to the source.
+5. Writes to `*.validasi.dart` next to the source.
 
 ### 3.2 `lib/src/generator.dart`
 
@@ -575,7 +575,7 @@ import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 import 'package:validasi_ui/validasi_ui.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass()
 class User { ... }

--- a/packages/validasi_gen/CHANGELOG.md
+++ b/packages/validasi_gen/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.0-rc.1
+
+### Breaking Changes
+
+- Generated output extension changed from `.g.dart` to `.validasi.dart` to avoid build
+  conflicts with other `build_runner` generators (e.g. `json_serializable`) sharing `.g.dart`.
+  Existing `part 'x.g.dart';` directives must be updated to `part 'x.validasi.dart';` and
+  projects must regenerate (`dart run build_runner build --delete-conflicting-outputs`).
+
 ## 0.1.0-dev.6
 
 ### Added

--- a/packages/validasi_gen/README.md
+++ b/packages/validasi_gen/README.md
@@ -17,7 +17,7 @@ Source model:
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass()
 class User {
@@ -38,7 +38,7 @@ You now have `UserFields<V>`, `UserNameField`, `UserEmailField`, and an `extensi
 
 ## What you get
 
-For every class annotated with `@ValidateClass`, the generator emits (into `*.g.dart` as a `part of` file):
+For every class annotated with `@ValidateClass`, the generator emits (into `*.validasi.dart` as a `part of` file):
 
 | Artifact | When | Purpose |
 |---|---|---|

--- a/packages/validasi_gen/build.yaml
+++ b/packages/validasi_gen/build.yaml
@@ -5,6 +5,6 @@ builders:
       - validasiBuilder
     build_extensions:
       ".dart":
-        - ".g.dart"
+        - ".validasi.dart"
     auto_apply: dependents
     build_to: source

--- a/packages/validasi_gen/example/analysis_options.yaml
+++ b/packages/validasi_gen/example/analysis_options.yaml
@@ -1,3 +1,3 @@
 analyzer:
   exclude:
-    - "**/*.g.dart"
+    - "**/*.validasi.dart"

--- a/packages/validasi_gen/example/lib/example.dart
+++ b/packages/validasi_gen/example/lib/example.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'example.g.dart';
+part 'example.validasi.dart';
 
 // Custom rule example — define a class extending CustomRule<T>,
 // with a static bool check(T? value, {required ...}) method.

--- a/packages/validasi_gen/example/lib/example.validasi.dart
+++ b/packages/validasi_gen/example/lib/example.validasi.dart
@@ -200,8 +200,7 @@ class UserWorkEmailField extends UserFields<String> {
           if (domain.isEmpty || domain.length > 255) return true;
           if (!RegExp(
             '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\$',
-          ).hasMatch(domain))
-            return true;
+          ).hasMatch(domain)) return true;
           final labels = domain.split('.');
           if (!false && labels.length < 2) return true;
           for (final label in labels) {
@@ -354,11 +353,9 @@ class UserPreviousCarsField extends UserFields<List<Car>> {
       );
     }
     final $errors = <ValidationError>[];
-    for (
-      var $previousCarsIndex = 0;
-      $previousCarsIndex < value.length;
-      $previousCarsIndex++
-    ) {
+    for (var $previousCarsIndex = 0;
+        $previousCarsIndex < value.length;
+        $previousCarsIndex++) {
       final $previousCarsItem = value[$previousCarsIndex];
       final $previousCarsResult = $previousCarsItem.validate();
       if (!$previousCarsResult.isValid) {
@@ -380,11 +377,9 @@ class UserPreviousCarsField extends UserFields<List<Car>> {
       );
     }
     final $errors = <ValidationError>[];
-    for (
-      var $previousCarsIndex = 0;
-      $previousCarsIndex < value.length;
-      $previousCarsIndex++
-    ) {
+    for (var $previousCarsIndex = 0;
+        $previousCarsIndex < value.length;
+        $previousCarsIndex++) {
       final $previousCarsItem = value[$previousCarsIndex];
       final $previousCarsResult = await $previousCarsItem.validateAsync();
       if (!$previousCarsResult.isValid) {
@@ -496,8 +491,7 @@ extension $UserValidasi on User {
       if (domain.isEmpty || domain.length > 255) return true;
       if (!RegExp(
         '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\$',
-      ).hasMatch(domain))
-        return true;
+      ).hasMatch(domain)) return true;
       final labels = domain.split('.');
       if (!false && labels.length < 2) return true;
       for (final label in labels) {
@@ -533,11 +527,9 @@ extension $UserValidasi on User {
       }
     }
     // Field: previousCars (nested Car)
-    for (
-      var $previousCarsIndex = 0;
-      $previousCarsIndex < previousCars.length;
-      $previousCarsIndex++
-    ) {
+    for (var $previousCarsIndex = 0;
+        $previousCarsIndex < previousCars.length;
+        $previousCarsIndex++) {
       final $previousCarsItem = previousCars[$previousCarsIndex];
       final $previousCarsItemResult = await $previousCarsItem.validateAsync();
       if (!$previousCarsItemResult.isValid) {
@@ -556,14 +548,14 @@ extension $UserValidasi on User {
     }
     final $fail_User_emailMatchesConfirm =
         ({required String message, List<String> path = const []}) {
-          $errors.add(
-            ValidationError(
-              rule: 'Refine',
-              message: message,
-              path: path.isEmpty ? null : path,
-            ),
-          );
-        };
+      $errors.add(
+        ValidationError(
+          rule: 'Refine',
+          message: message,
+          path: path.isEmpty ? null : path,
+        ),
+      );
+    };
     User.emailMatchesConfirm(
       $fail_User_emailMatchesConfirm,
       email: email,
@@ -720,14 +712,14 @@ extension $ContactInfoValidasi on ContactInfo {
     final $errors = <ValidationError>[];
     final $fail__ContactInfoCrossFieldRules_requiredAny_0 =
         ({required String message, List<String> path = const []}) {
-          $errors.add(
-            ValidationError(
-              rule: 'RequiredAny',
-              message: message,
-              path: path.isEmpty ? null : path,
-            ),
-          );
-        };
+      $errors.add(
+        ValidationError(
+          rule: 'RequiredAny',
+          message: message,
+          path: path.isEmpty ? null : path,
+        ),
+      );
+    };
     _ContactInfoCrossFieldRules.requiredAny_0(
       $fail__ContactInfoCrossFieldRules_requiredAny_0,
       email: email,
@@ -735,14 +727,14 @@ extension $ContactInfoValidasi on ContactInfo {
     );
     final $fail__ContactInfoCrossFieldRules_matchesField_0 =
         ({required String message, List<String> path = const []}) {
-          $errors.add(
-            ValidationError(
-              rule: 'MatchesField',
-              message: message,
-              path: path.isEmpty ? null : path,
-            ),
-          );
-        };
+      $errors.add(
+        ValidationError(
+          rule: 'MatchesField',
+          message: message,
+          path: path.isEmpty ? null : path,
+        ),
+      );
+    };
     _ContactInfoCrossFieldRules.matchesField_0(
       $fail__ContactInfoCrossFieldRules_matchesField_0,
       password: password,
@@ -758,14 +750,14 @@ extension $ContactInfoValidasi on ContactInfo {
     final $errors = <ValidationError>[];
     final $fail__ContactInfoCrossFieldRules_requiredAny_0 =
         ({required String message, List<String> path = const []}) {
-          $errors.add(
-            ValidationError(
-              rule: 'RequiredAny',
-              message: message,
-              path: path.isEmpty ? null : path,
-            ),
-          );
-        };
+      $errors.add(
+        ValidationError(
+          rule: 'RequiredAny',
+          message: message,
+          path: path.isEmpty ? null : path,
+        ),
+      );
+    };
     _ContactInfoCrossFieldRules.requiredAny_0(
       $fail__ContactInfoCrossFieldRules_requiredAny_0,
       email: email,
@@ -773,14 +765,14 @@ extension $ContactInfoValidasi on ContactInfo {
     );
     final $fail__ContactInfoCrossFieldRules_matchesField_0 =
         ({required String message, List<String> path = const []}) {
-          $errors.add(
-            ValidationError(
-              rule: 'MatchesField',
-              message: message,
-              path: path.isEmpty ? null : path,
-            ),
-          );
-        };
+      $errors.add(
+        ValidationError(
+          rule: 'MatchesField',
+          message: message,
+          path: path.isEmpty ? null : path,
+        ),
+      );
+    };
     _ContactInfoCrossFieldRules.matchesField_0(
       $fail__ContactInfoCrossFieldRules_matchesField_0,
       password: password,
@@ -829,40 +821,44 @@ abstract final class _Errors {
     List<String> path,
     int length, {
     String? message,
-  }) => ValidationError(
-    rule: 'MinLength',
-    message: message ?? 'Minimum length is $length characters',
-    details: {'length': '$length'},
-    path: path,
-  );
+  }) =>
+      ValidationError(
+        rule: 'MinLength',
+        message: message ?? 'Minimum length is $length characters',
+        details: {'length': '$length'},
+        path: path,
+      );
 
   static ValidationError maxLength(
     List<String> path,
     int length, {
     String? message,
-  }) => ValidationError(
-    rule: 'MaxLength',
-    message: message ?? 'Maximum length is $length characters',
-    details: {'length': '$length'},
-    path: path,
-  );
+  }) =>
+      ValidationError(
+        rule: 'MaxLength',
+        message: message ?? 'Maximum length is $length characters',
+        details: {'length': '$length'},
+        path: path,
+      );
 
   static ValidationError inline(
     List<String> path,
     String rule,
     String message,
-  ) => ValidationError(rule: rule, message: message, path: path);
+  ) =>
+      ValidationError(rule: rule, message: message, path: path);
 
   static ValidationError itMinLength(
     List<String> path,
     int length, {
     String? message,
-  }) => ValidationError(
-    rule: 'MinLength',
-    message: message ?? 'List must have at least $length items',
-    details: {'length': '$length'},
-    path: path,
-  );
+  }) =>
+      ValidationError(
+        rule: 'MinLength',
+        message: message ?? 'List must have at least $length items',
+        details: {'length': '$length'},
+        path: path,
+      );
 
   static ValidationError unique(List<String> path, {String? message}) =>
       ValidationError(
@@ -882,30 +878,32 @@ abstract final class _Errors {
     List<String> path,
     String suffix, {
     String? message,
-  }) => ValidationError(
-    rule: 'EndsWith',
-    message: message ?? 'Must end with "$suffix"',
-    details: {'suffix': suffix},
-    path: path,
-  );
+  }) =>
+      ValidationError(
+        rule: 'EndsWith',
+        message: message ?? 'Must end with "$suffix"',
+        details: {'suffix': suffix},
+        path: path,
+      );
 
   static ValidationError between(
     List<String> path,
     num min,
     num max, {
     String? message,
-  }) => ValidationError(
-    rule: 'Between',
-    message: message ?? 'Value must be between $min and $max',
-    path: path,
-  );
+  }) =>
+      ValidationError(
+        rule: 'Between',
+        message: message ?? 'Value must be between $min and $max',
+        path: path,
+      );
 }
 
 abstract final class _Result {
   static ValidasiResult<T> from<T>(List<ValidationError> errors, T? value) =>
       errors.isEmpty
-      ? ValidasiResult(errors: const [], isValid: true, data: value)
-      : ValidasiResult(errors: errors, isValid: false);
+          ? ValidasiResult(errors: const [], isValid: true, data: value)
+          : ValidasiResult(errors: errors, isValid: false);
 
   static ValidasiResult<T> invalidSingle<T>(ValidationError error) =>
       ValidasiResult(errors: [error], isValid: false);

--- a/packages/validasi_gen/example/lib/example.validasi.dart
+++ b/packages/validasi_gen/example/lib/example.validasi.dart
@@ -200,7 +200,8 @@ class UserWorkEmailField extends UserFields<String> {
           if (domain.isEmpty || domain.length > 255) return true;
           if (!RegExp(
             '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\$',
-          ).hasMatch(domain)) return true;
+          ).hasMatch(domain))
+            return true;
           final labels = domain.split('.');
           if (!false && labels.length < 2) return true;
           for (final label in labels) {
@@ -353,9 +354,11 @@ class UserPreviousCarsField extends UserFields<List<Car>> {
       );
     }
     final $errors = <ValidationError>[];
-    for (var $previousCarsIndex = 0;
-        $previousCarsIndex < value.length;
-        $previousCarsIndex++) {
+    for (
+      var $previousCarsIndex = 0;
+      $previousCarsIndex < value.length;
+      $previousCarsIndex++
+    ) {
       final $previousCarsItem = value[$previousCarsIndex];
       final $previousCarsResult = $previousCarsItem.validate();
       if (!$previousCarsResult.isValid) {
@@ -377,9 +380,11 @@ class UserPreviousCarsField extends UserFields<List<Car>> {
       );
     }
     final $errors = <ValidationError>[];
-    for (var $previousCarsIndex = 0;
-        $previousCarsIndex < value.length;
-        $previousCarsIndex++) {
+    for (
+      var $previousCarsIndex = 0;
+      $previousCarsIndex < value.length;
+      $previousCarsIndex++
+    ) {
       final $previousCarsItem = value[$previousCarsIndex];
       final $previousCarsResult = await $previousCarsItem.validateAsync();
       if (!$previousCarsResult.isValid) {
@@ -491,7 +496,8 @@ extension $UserValidasi on User {
       if (domain.isEmpty || domain.length > 255) return true;
       if (!RegExp(
         '^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\$',
-      ).hasMatch(domain)) return true;
+      ).hasMatch(domain))
+        return true;
       final labels = domain.split('.');
       if (!false && labels.length < 2) return true;
       for (final label in labels) {
@@ -527,9 +533,11 @@ extension $UserValidasi on User {
       }
     }
     // Field: previousCars (nested Car)
-    for (var $previousCarsIndex = 0;
-        $previousCarsIndex < previousCars.length;
-        $previousCarsIndex++) {
+    for (
+      var $previousCarsIndex = 0;
+      $previousCarsIndex < previousCars.length;
+      $previousCarsIndex++
+    ) {
       final $previousCarsItem = previousCars[$previousCarsIndex];
       final $previousCarsItemResult = await $previousCarsItem.validateAsync();
       if (!$previousCarsItemResult.isValid) {
@@ -548,14 +556,14 @@ extension $UserValidasi on User {
     }
     final $fail_User_emailMatchesConfirm =
         ({required String message, List<String> path = const []}) {
-      $errors.add(
-        ValidationError(
-          rule: 'Refine',
-          message: message,
-          path: path.isEmpty ? null : path,
-        ),
-      );
-    };
+          $errors.add(
+            ValidationError(
+              rule: 'Refine',
+              message: message,
+              path: path.isEmpty ? null : path,
+            ),
+          );
+        };
     User.emailMatchesConfirm(
       $fail_User_emailMatchesConfirm,
       email: email,
@@ -712,14 +720,14 @@ extension $ContactInfoValidasi on ContactInfo {
     final $errors = <ValidationError>[];
     final $fail__ContactInfoCrossFieldRules_requiredAny_0 =
         ({required String message, List<String> path = const []}) {
-      $errors.add(
-        ValidationError(
-          rule: 'RequiredAny',
-          message: message,
-          path: path.isEmpty ? null : path,
-        ),
-      );
-    };
+          $errors.add(
+            ValidationError(
+              rule: 'RequiredAny',
+              message: message,
+              path: path.isEmpty ? null : path,
+            ),
+          );
+        };
     _ContactInfoCrossFieldRules.requiredAny_0(
       $fail__ContactInfoCrossFieldRules_requiredAny_0,
       email: email,
@@ -727,14 +735,14 @@ extension $ContactInfoValidasi on ContactInfo {
     );
     final $fail__ContactInfoCrossFieldRules_matchesField_0 =
         ({required String message, List<String> path = const []}) {
-      $errors.add(
-        ValidationError(
-          rule: 'MatchesField',
-          message: message,
-          path: path.isEmpty ? null : path,
-        ),
-      );
-    };
+          $errors.add(
+            ValidationError(
+              rule: 'MatchesField',
+              message: message,
+              path: path.isEmpty ? null : path,
+            ),
+          );
+        };
     _ContactInfoCrossFieldRules.matchesField_0(
       $fail__ContactInfoCrossFieldRules_matchesField_0,
       password: password,
@@ -750,14 +758,14 @@ extension $ContactInfoValidasi on ContactInfo {
     final $errors = <ValidationError>[];
     final $fail__ContactInfoCrossFieldRules_requiredAny_0 =
         ({required String message, List<String> path = const []}) {
-      $errors.add(
-        ValidationError(
-          rule: 'RequiredAny',
-          message: message,
-          path: path.isEmpty ? null : path,
-        ),
-      );
-    };
+          $errors.add(
+            ValidationError(
+              rule: 'RequiredAny',
+              message: message,
+              path: path.isEmpty ? null : path,
+            ),
+          );
+        };
     _ContactInfoCrossFieldRules.requiredAny_0(
       $fail__ContactInfoCrossFieldRules_requiredAny_0,
       email: email,
@@ -765,14 +773,14 @@ extension $ContactInfoValidasi on ContactInfo {
     );
     final $fail__ContactInfoCrossFieldRules_matchesField_0 =
         ({required String message, List<String> path = const []}) {
-      $errors.add(
-        ValidationError(
-          rule: 'MatchesField',
-          message: message,
-          path: path.isEmpty ? null : path,
-        ),
-      );
-    };
+          $errors.add(
+            ValidationError(
+              rule: 'MatchesField',
+              message: message,
+              path: path.isEmpty ? null : path,
+            ),
+          );
+        };
     _ContactInfoCrossFieldRules.matchesField_0(
       $fail__ContactInfoCrossFieldRules_matchesField_0,
       password: password,
@@ -821,44 +829,40 @@ abstract final class _Errors {
     List<String> path,
     int length, {
     String? message,
-  }) =>
-      ValidationError(
-        rule: 'MinLength',
-        message: message ?? 'Minimum length is $length characters',
-        details: {'length': '$length'},
-        path: path,
-      );
+  }) => ValidationError(
+    rule: 'MinLength',
+    message: message ?? 'Minimum length is $length characters',
+    details: {'length': '$length'},
+    path: path,
+  );
 
   static ValidationError maxLength(
     List<String> path,
     int length, {
     String? message,
-  }) =>
-      ValidationError(
-        rule: 'MaxLength',
-        message: message ?? 'Maximum length is $length characters',
-        details: {'length': '$length'},
-        path: path,
-      );
+  }) => ValidationError(
+    rule: 'MaxLength',
+    message: message ?? 'Maximum length is $length characters',
+    details: {'length': '$length'},
+    path: path,
+  );
 
   static ValidationError inline(
     List<String> path,
     String rule,
     String message,
-  ) =>
-      ValidationError(rule: rule, message: message, path: path);
+  ) => ValidationError(rule: rule, message: message, path: path);
 
   static ValidationError itMinLength(
     List<String> path,
     int length, {
     String? message,
-  }) =>
-      ValidationError(
-        rule: 'MinLength',
-        message: message ?? 'List must have at least $length items',
-        details: {'length': '$length'},
-        path: path,
-      );
+  }) => ValidationError(
+    rule: 'MinLength',
+    message: message ?? 'List must have at least $length items',
+    details: {'length': '$length'},
+    path: path,
+  );
 
   static ValidationError unique(List<String> path, {String? message}) =>
       ValidationError(
@@ -878,32 +882,30 @@ abstract final class _Errors {
     List<String> path,
     String suffix, {
     String? message,
-  }) =>
-      ValidationError(
-        rule: 'EndsWith',
-        message: message ?? 'Must end with "$suffix"',
-        details: {'suffix': suffix},
-        path: path,
-      );
+  }) => ValidationError(
+    rule: 'EndsWith',
+    message: message ?? 'Must end with "$suffix"',
+    details: {'suffix': suffix},
+    path: path,
+  );
 
   static ValidationError between(
     List<String> path,
     num min,
     num max, {
     String? message,
-  }) =>
-      ValidationError(
-        rule: 'Between',
-        message: message ?? 'Value must be between $min and $max',
-        path: path,
-      );
+  }) => ValidationError(
+    rule: 'Between',
+    message: message ?? 'Value must be between $min and $max',
+    path: path,
+  );
 }
 
 abstract final class _Result {
   static ValidasiResult<T> from<T>(List<ValidationError> errors, T? value) =>
       errors.isEmpty
-          ? ValidasiResult(errors: const [], isValid: true, data: value)
-          : ValidasiResult(errors: errors, isValid: false);
+      ? ValidasiResult(errors: const [], isValid: true, data: value)
+      : ValidasiResult(errors: errors, isValid: false);
 
   static ValidasiResult<T> invalidSingle<T>(ValidationError error) =>
       ValidasiResult(errors: [error], isValid: false);

--- a/packages/validasi_gen/example/test/example_test.dart
+++ b/packages/validasi_gen/example/test/example_test.dart
@@ -567,7 +567,7 @@ void main() {
     });
 
     test('opt-out suppresses XFields from generated source', () {
-      final generated = File('lib/example.g.dart').readAsStringSync();
+      final generated = File('lib/example.validasi.dart').readAsStringSync();
       expect(generated, isNot(contains('class InternalFooFields')));
       expect(generated, isNot(contains('InternalFooFields<')));
       expect(generated, isNot(contains('validateField<InternalFooFields')));

--- a/packages/validasi_gen/lib/src/builder.dart
+++ b/packages/validasi_gen/lib/src/builder.dart
@@ -18,7 +18,7 @@ class _ValidasiBuilder implements Builder {
 
   @override
   Map<String, List<String>> get buildExtensions => const {
-        '.dart': ['.g.dart'],
+        '.dart': ['.validasi.dart'],
       };
 
   @override
@@ -45,7 +45,7 @@ class _ValidasiBuilder implements Builder {
     if (output.isEmpty) return;
 
     final inputFile = buildStep.inputId.pathSegments.last;
-    final outputId = buildStep.inputId.changeExtension('.g.dart');
+    final outputId = buildStep.inputId.changeExtension('.validasi.dart');
 
     final unformatted = '''// GENERATED CODE - DO NOT MODIFY BY HAND
 

--- a/packages/validasi_gen/pubspec.yaml
+++ b/packages/validasi_gen/pubspec.yaml
@@ -1,6 +1,6 @@
 name: validasi_gen
 description: Code generator for Validasi - compile-time validation with zero-cost abstraction.
-version: 0.1.0-dev.6
+version: 1.0.0-rc.1
 repository: https://github.com/albetnov/validasi
 homepage: https://albetnov.github.io/validasi
 

--- a/packages/validasi_gen/test/generator_test.dart
+++ b/packages/validasi_gen/test/generator_test.dart
@@ -29,7 +29,7 @@ void main() {
       expect(
           builder.buildExtensions,
           equals({
-            '.dart': ['.g.dart']
+            '.dart': ['.validasi.dart']
           }));
     });
   });

--- a/packages/validasi_ui/README.md
+++ b/packages/validasi_ui/README.md
@@ -47,7 +47,7 @@ Define the model and its rules in one place:
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass()
 class User {
@@ -74,7 +74,7 @@ Run the generator:
 dart run build_runner build
 ```
 
-This produces `user.g.dart` containing the `UserFields<V>` sealed hierarchy and, because
+This produces `user.validasi.dart` containing the `UserFields<V>` sealed hierarchy and, because
 `generateSchema`/`generateValidateForm` are on, `UserFields.schema` (pass straight to
 `ValidasiForm(schema: UserFields.schema)`) and `validateForm_User(controller)` for the cross-field
 rules. Both `generateSchema` and `generateValidateForm` are no-ops unless `generateFields` is also

--- a/packages/validasi_ui/example/lib/main.dart
+++ b/packages/validasi_ui/example/lib/main.dart
@@ -67,7 +67,7 @@ class UserFormPage extends StatelessWidget {
               const UserSummary(),
               const SizedBox(height: 16),
               ValidasiTextField(
-                field: UserFields.name,
+                field: UserFields.name_,
                 builder: (context, state, ctrl) => TextField(
                   controller: ctrl,
                   onChanged: state.onChanged,

--- a/packages/validasi_ui/example/lib/user.dart
+++ b/packages/validasi_ui/example/lib/user.dart
@@ -1,7 +1,7 @@
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass(generateFields: true)
 class User {

--- a/packages/validasi_ui/example/lib/user.validasi.dart
+++ b/packages/validasi_ui/example/lib/user.validasi.dart
@@ -8,7 +8,7 @@ sealed class UserFields<V> extends ValidasiKey<User>
 
   static const ValidasiSchema<User> schema = _UserSchema();
 
-  static const UserFields<String> name = UserNameField();
+  static const UserFields<String> name_ = UserNameField();
 
   static const UserFields<String> email = UserEmailField();
 
@@ -108,7 +108,7 @@ class _UserSchema extends ValidasiSchema<User> {
   @override
   User allocate(ValidasiFieldReader<User> reader) {
     return User(
-      name: reader.getValue(UserFields.name) as String,
+      name: reader.getValue(UserFields.name_) as String,
       email: reader.getValue(UserFields.email) as String,
       age: reader.getValue(UserFields.age) as int,
     );
@@ -138,14 +138,14 @@ extension $UserValidasi on User {
     }
     final $fail_User_emailDoesNotStartWithName =
         ({required String message, List<String> path = const []}) {
-      $errors.add(
-        ValidationError(
-          rule: 'Refine',
-          message: message,
-          path: path.isEmpty ? null : path,
-        ),
-      );
-    };
+          $errors.add(
+            ValidationError(
+              rule: 'Refine',
+              message: message,
+              path: path.isEmpty ? null : path,
+            ),
+          );
+        };
     User.emailDoesNotStartWithName(
       $fail_User_emailDoesNotStartWithName,
       name: name,
@@ -179,14 +179,14 @@ extension $UserValidasi on User {
     }
     final $fail_User_emailDoesNotStartWithName =
         ({required String message, List<String> path = const []}) {
-      $errors.add(
-        ValidationError(
-          rule: 'Refine',
-          message: message,
-          path: path.isEmpty ? null : path,
-        ),
-      );
-    };
+          $errors.add(
+            ValidationError(
+              rule: 'Refine',
+              message: message,
+              path: path.isEmpty ? null : path,
+            ),
+          );
+        };
     User.emailDoesNotStartWithName(
       $fail_User_emailDoesNotStartWithName,
       name: name,
@@ -219,44 +219,41 @@ abstract final class _Errors {
     List<String> path,
     int length, {
     String? message,
-  }) =>
-      ValidationError(
-        rule: 'MinLength',
-        message: message ?? 'Minimum length is $length characters',
-        details: {'length': '$length'},
-        path: path,
-      );
+  }) => ValidationError(
+    rule: 'MinLength',
+    message: message ?? 'Minimum length is $length characters',
+    details: {'length': '$length'},
+    path: path,
+  );
 
   static ValidationError maxLength(
     List<String> path,
     int length, {
     String? message,
-  }) =>
-      ValidationError(
-        rule: 'MaxLength',
-        message: message ?? 'Maximum length is $length characters',
-        details: {'length': '$length'},
-        path: path,
-      );
+  }) => ValidationError(
+    rule: 'MaxLength',
+    message: message ?? 'Maximum length is $length characters',
+    details: {'length': '$length'},
+    path: path,
+  );
 
   static ValidationError oneOf(
     List<String> path,
     List<Object?> options, {
     String? message,
-  }) =>
-      ValidationError(
-        rule: 'OneOf',
-        message: message ?? 'Value must be one of: ${options.join(", ")}',
-        details: {'options': '${options.join(",")}'},
-        path: path,
-      );
+  }) => ValidationError(
+    rule: 'OneOf',
+    message: message ?? 'Value must be one of: ${options.join(", ")}',
+    details: {'options': '${options.join(",")}'},
+    path: path,
+  );
 }
 
 abstract final class _Result {
   static ValidasiResult<T> from<T>(List<ValidationError> errors, T? value) =>
       errors.isEmpty
-          ? ValidasiResult(errors: const [], isValid: true, data: value)
-          : ValidasiResult(errors: errors, isValid: false);
+      ? ValidasiResult(errors: const [], isValid: true, data: value)
+      : ValidasiResult(errors: errors, isValid: false);
 
   static ValidasiResult<T> invalidSingle<T>(ValidationError error) =>
       ValidasiResult(errors: [error], isValid: false);

--- a/packages/validasi_ui/example/lib/user.validasi.dart
+++ b/packages/validasi_ui/example/lib/user.validasi.dart
@@ -138,14 +138,14 @@ extension $UserValidasi on User {
     }
     final $fail_User_emailDoesNotStartWithName =
         ({required String message, List<String> path = const []}) {
-          $errors.add(
-            ValidationError(
-              rule: 'Refine',
-              message: message,
-              path: path.isEmpty ? null : path,
-            ),
-          );
-        };
+      $errors.add(
+        ValidationError(
+          rule: 'Refine',
+          message: message,
+          path: path.isEmpty ? null : path,
+        ),
+      );
+    };
     User.emailDoesNotStartWithName(
       $fail_User_emailDoesNotStartWithName,
       name: name,
@@ -179,14 +179,14 @@ extension $UserValidasi on User {
     }
     final $fail_User_emailDoesNotStartWithName =
         ({required String message, List<String> path = const []}) {
-          $errors.add(
-            ValidationError(
-              rule: 'Refine',
-              message: message,
-              path: path.isEmpty ? null : path,
-            ),
-          );
-        };
+      $errors.add(
+        ValidationError(
+          rule: 'Refine',
+          message: message,
+          path: path.isEmpty ? null : path,
+        ),
+      );
+    };
     User.emailDoesNotStartWithName(
       $fail_User_emailDoesNotStartWithName,
       name: name,
@@ -219,41 +219,44 @@ abstract final class _Errors {
     List<String> path,
     int length, {
     String? message,
-  }) => ValidationError(
-    rule: 'MinLength',
-    message: message ?? 'Minimum length is $length characters',
-    details: {'length': '$length'},
-    path: path,
-  );
+  }) =>
+      ValidationError(
+        rule: 'MinLength',
+        message: message ?? 'Minimum length is $length characters',
+        details: {'length': '$length'},
+        path: path,
+      );
 
   static ValidationError maxLength(
     List<String> path,
     int length, {
     String? message,
-  }) => ValidationError(
-    rule: 'MaxLength',
-    message: message ?? 'Maximum length is $length characters',
-    details: {'length': '$length'},
-    path: path,
-  );
+  }) =>
+      ValidationError(
+        rule: 'MaxLength',
+        message: message ?? 'Maximum length is $length characters',
+        details: {'length': '$length'},
+        path: path,
+      );
 
   static ValidationError oneOf(
     List<String> path,
     List<Object?> options, {
     String? message,
-  }) => ValidationError(
-    rule: 'OneOf',
-    message: message ?? 'Value must be one of: ${options.join(", ")}',
-    details: {'options': '${options.join(",")}'},
-    path: path,
-  );
+  }) =>
+      ValidationError(
+        rule: 'OneOf',
+        message: message ?? 'Value must be one of: ${options.join(", ")}',
+        details: {'options': '${options.join(",")}'},
+        path: path,
+      );
 }
 
 abstract final class _Result {
   static ValidasiResult<T> from<T>(List<ValidationError> errors, T? value) =>
       errors.isEmpty
-      ? ValidasiResult(errors: const [], isValid: true, data: value)
-      : ValidasiResult(errors: errors, isValid: false);
+          ? ValidasiResult(errors: const [], isValid: true, data: value)
+          : ValidasiResult(errors: errors, isValid: false);
 
   static ValidasiResult<T> invalidSingle<T>(ValidationError error) =>
       ValidasiResult(errors: [error], isValid: false);

--- a/packages/validasi_ui/example/lib/user_summary.dart
+++ b/packages/validasi_ui/example/lib/user_summary.dart
@@ -10,15 +10,15 @@ class UserSummary extends StatelessWidget {
     return ValidasiWatch.form<User>(
       builder: (context, controller) {
         final preview = controller.watch<String, String>(
-          [UserFields.name, UserFields.email],
+          [UserFields.name_, UserFields.email],
           (values) {
-            final name = values[UserFields.name] ?? '?';
+            final name = values[UserFields.name_] ?? '?';
             final email = values[UserFields.email] ?? '?';
             return '$name <$email>';
           },
         );
 
-        final nameSignal = controller.watchValue(UserFields.name);
+        final nameSignal = controller.watchValue(UserFields.name_);
         final emailSignal = controller.watchValue(UserFields.email);
         final ageSignal = controller.watchValue(UserFields.age);
         final isReady = nameSignal.value != null &&

--- a/skills/validasi-gen/SKILL.md
+++ b/skills/validasi-gen/SKILL.md
@@ -5,17 +5,17 @@ description: >-
   validasi_annotation, instead of hand-writing validasi schemas. Use this whenever the user
   annotates a class with @ValidateClass or @Validate<T>, runs build_runner for validation code,
   asks which validasi_gen build flag to turn on (generateFields/generateSchema/generateValidateForm/
-  generateIndexedFields), needs a *.g.dart validator regenerated, or wants a custom, async, or
+  generateIndexedFields), needs a *.validasi.dart validator regenerated, or wants a custom, async, or
   cross-field rule wired into a generated class — Inline, AsyncInline, CustomRule, AsyncCustomRule,
   RefineFn, or the cross-field sugar annotations (@RequiredAny, @MatchesField, etc). Reach for this
-  skill whenever validasi_gen, validasi_annotation, @ValidateClass, or a generated validasi *.g.dart
+  skill whenever validasi_gen, validasi_annotation, @ValidateClass, or a generated validasi *.validasi.dart
   file appears in the code or request, even if the user doesn't name the package explicitly.
 ---
 
 # Validasi Gen
 
 `validasi_gen` is the `build_runner` code generator for `validasi`: annotate a plain Dart class
-with `@ValidateClass` and field-level `@Validate<T>([...])`, run the build, and get a `*.g.dart`
+with `@ValidateClass` and field-level `@Validate<T>([...])`, run the build, and get a `*.validasi.dart`
 part file with a sealed field hierarchy plus `validate()`/`validateAsync()` extension methods —
 instead of hand-writing a `Validasi.*` builder. This skill is the curated, always-in-context
 reference for the codegen decisions; deep catalogs live in `references/`.
@@ -31,7 +31,7 @@ dart pub add --dev build_runner validasi_gen
 import 'package:validasi/validasi.dart';
 import 'package:validasi_annotation/validasi_annotation.dart';
 
-part 'user.g.dart';
+part 'user.validasi.dart';
 
 @ValidateClass()
 class User {
@@ -44,7 +44,7 @@ class User {
 
 Run `dart run build_runner build --delete-conflicting-outputs` (or `watch`) to (re)generate. The
 builder declares `auto_apply: dependents` and `build_to: source`, so any package depending on
-`validasi_gen` gets its `.g.dart` written next to the source file automatically — the `part`
+`validasi_gen` gets its `.validasi.dart` written next to the source file automatically — the `part`
 directive is the only manual wiring needed.
 
 ## Build flags

--- a/skills/validasi-gen/references/gotchas.md
+++ b/skills/validasi-gen/references/gotchas.md
@@ -37,7 +37,7 @@ obviously-named field doesn't compile, check whether it's one of these four rese
 
 ## Regenerate after any annotation change
 
-Because `.g.dart` is a checked-in-adjacent generated `part` file, editing an annotation
+Because `.validasi.dart` is a checked-in-adjacent generated `part` file, editing an annotation
 (`@Validate<T>([...])`, `@ValidateClass(...)`, a `@RefineFn`, adding a field) has no effect until
 you rerun the build:
 
@@ -46,7 +46,7 @@ dart run build_runner build --delete-conflicting-outputs
 ```
 
 Prefer `--delete-conflicting-outputs` over debugging stale build errors — a renamed or removed
-field can leave an orphaned `.g.dart` output that the builder refuses to overwrite silently.
+field can leave an orphaned `.validasi.dart` output that the builder refuses to overwrite silently.
 
 ## Docs vs. source
 


### PR DESCRIPTION
- Changed the output file extension in the validasi_gen package from .g.dart to .validasi.dart to better reflect its purpose.
- Updated references in example tests, README, and user model files to use the new .validasi.dart extension.
- Adjusted build extensions and output ID in the builder to accommodate the new file naming convention.
- Ensured all relevant tests and documentation are aligned with the new file structure.